### PR TITLE
Move interfaces related to docker from upstream policy.

### DIFF
--- a/docker.te
+++ b/docker.te
@@ -323,3 +323,38 @@ optional_policy(`
 optional_policy(`
 	virt_transition_svirt_sandbox(spc_t, system_r)
 ')
+
+########################################
+#
+# docker upstream policy
+#
+
+optional_policy(`
+    domain_stub_named_filetrans_domain()
+    docker_filetrans_named_content(named_filetrans_domain)
+')
+
+optional_policy(`
+    lvm_stub()
+    docker_rw_sem(lvm_t)
+')
+
+optional_policy(`
+    staff_stub()
+    docker_stream_connect(staff_t)
+    docker_exec(staff_t)
+')
+
+optional_policy(`
+    virt_stub_lxc()
+    docker_exec_lib(virtd_lxc_t)
+')
+
+optional_policy(`
+    virt_stub_svirt_sandbox_domain()
+    virt_stub_svirt_sandbox_file()
+    docker_read_share_files(svirt_sandbox_domain)
+    docker_lib_filetrans(svirt_sandbox_domain,svirt_sandbox_file_t, sock_file)
+    docker_use_ptys(svirt_sandbox_domain)
+    docker_spc_stream_connect(svirt_sandbox_domain)
+')


### PR DESCRIPTION
Move interfaces related to docker from upstream policy together with stub() interfaces until we get better solution.