### PR TITLE
Turn on virt booleans for use with docker

### DIFF
--- a/docker-selinux.spec
+++ b/docker-selinux.spec
@@ -63,13 +63,15 @@ install -m 0644 $MODULES \
 #
 # Install all modules in a single transaction
 #
+if [ $1 -eq 1 ]; then
+    %{_sbindir}/setsebool -P -N virt_use_nfs=1 virt_sandbox_use_all_caps=1
+fi
 %_format MODULES %{_datadir}/selinux/packages/$x.pp.bz2
 %{_sbindir}/semodule -n -s %{selinuxtype} -i $MODULES
 if %{_sbindir}/selinuxenabled ; then
     %{_sbindir}/load_policy
     %relabel_files
 fi
-
 
 %postun
 if [ $1 -eq 0 ]; then


### PR DESCRIPTION
I think we should default to virt_use_nfs to handle clustered
situations where selinux blocks nfs volumes.  This makes docker
containers a little less secure, but improves usability.

Secondly we need to turn on virt_sandbox_use_all_caps to allod
docker run --cap-add to actually work.  Having SELinux break this
out of the box kind of stinks.  This gives slightly less security
since the kernel already controls the capabilities separately.