### PR TITLE
Add policy for docker_auth  plugins

### DIFF
--- a/docker.fc
+++ b/docker.fc
@@ -1,8 +1,11 @@
 /root/\.docker	gen_context(system_u:object_r:docker_home_t,s0)
 
 /usr/bin/docker			--	gen_context(system_u:object_r:docker_exec_t,s0)
+/usr/bin/docker-novolume-plugin		--	gen_context(system_u:object_r:docker_auth_exec_t,s0)
+/usr/lib/docker/docker-novolume-plugin	--	gen_context(system_u:object_r:docker_auth_exec_t,s0)
 
 /usr/lib/systemd/system/docker.service		--	gen_context(system_u:object_r:docker_unit_file_t,s0)
+/usr/lib/systemd/system/docker-novolume-plugin.service	--	gen_context(system_u:object_r:docker_unit_file_t,s0)
 
 /etc/docker(/.*)?		gen_context(system_u:object_r:docker_config_t,s0)
 
@@ -10,9 +13,11 @@
 /var/lib/kublet(/.*)?		gen_context(system_u:object_r:docker_var_lib_t,s0)
 /var/lib/docker/vfs(/.*)?	gen_context(system_u:object_r:svirt_sandbox_file_t,s0)
 
+/var/run/docker(/.*)?		gen_context(system_u:object_r:docker_var_run_t,s0)
 /var/run/docker\.pid		--	gen_context(system_u:object_r:docker_var_run_t,s0)
 /var/run/docker\.sock		-s	gen_context(system_u:object_r:docker_var_run_t,s0)
 /var/run/docker-client(/.*)?		gen_context(system_u:object_r:docker_var_run_t,s0)
+/var/run/docker/plugins(/.*)?		gen_context(system_u:object_r:docker_plugin_var_run_t,s0)
 
 /var/lock/lxc(/.*)?		gen_context(system_u:object_r:docker_lock_t,s0)
 
@@ -22,4 +27,3 @@
 /var/lib/docker/containers/.*/hosts		gen_context(system_u:object_r:docker_share_t,s0)
 /var/lib/docker/containers/.*/hostname		gen_context(system_u:object_r:docker_share_t,s0)
 /var/lib/docker/.*/config\.env	gen_context(system_u:object_r:docker_share_t,s0)
-

--- a/docker.if
+++ b/docker.if
@@ -341,7 +341,6 @@ interface(`docker_spc_stream_connect',`
 	allow $1 spc_t:unix_stream_socket connectto;
 ')
 
-
 ########################################
 ## <summary>
 ##	All of the rules required to administrate
@@ -464,4 +463,61 @@ interface(`dev_dontaudit_mounton_sysfs',`
 	')
 
 	dontaudit $1 sysfs_t:dir mounton;
+')
+
+########################################
+## <summary>
+##	Execute docker_auth_exec_t in the docker_auth domain.
+## </summary>
+## <param name="domain">
+## <summary>
+##	Domain allowed to transition.
+## </summary>
+## </param>
+#
+interface(`docker_auth_domtrans',`
+	gen_require(`
+		type docker_auth_t, docker_auth_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	domtrans_pattern($1, docker_auth_exec_t, docker_auth_t)
+')
+
+######################################
+## <summary>
+##	Execute docker_auth in the caller domain.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_auth_exec',`
+	gen_require(`
+		type docker_auth_exec_t;
+	')
+
+	corecmd_search_bin($1)
+	can_exec($1, docker_auth_exec_t)
+')
+
+########################################
+## <summary>
+##	Connect to docker_auth over a unix stream socket.
+## </summary>
+## <param name="domain">
+##	<summary>
+##	Domain allowed access.
+##	</summary>
+## </param>
+#
+interface(`docker_auth_stream_connect',`
+	gen_require(`
+		type docker_auth_t, docker_plugin_var_run_t;
+	')
+
+	files_search_pids($1)
+	stream_connect_pattern($1, docker_plugin_var_run_t, docker_plugin_var_run_t, docker_auth_t)
 ')

--- a/docker.te
+++ b/docker.te
@@ -6,13 +6,6 @@ policy_module(docker, 1.0.0)
 #
 
 ## <desc>
-## <p>
-## Allow sandbox containers manage fuse files
-## </p>
-## </desc>
-gen_tunable(virt_sandbox_use_fusefs, false)
-
-## <desc>
 ##  <p>
 ##  Determine whether docker can
 ##  connect to all TCP ports.
@@ -29,6 +22,10 @@ domain_role_change_exemption(docker_t)
 type spc_t;
 domain_type(spc_t)
 role system_r types spc_t;
+
+type docker_auth_t;
+type docker_auth_exec_t;
+init_daemon_domain(docker_auth_t, docker_auth_exec_t)
 
 type spc_var_run_t;
 files_pid_file(spc_var_run_t)
@@ -57,6 +54,9 @@ files_tmpfs_file(docker_tmpfs_t)
 type docker_var_run_t;
 files_pid_file(docker_var_run_t)
 
+type docker_plugin_var_run_t;
+files_pid_file(docker_plugin_var_run_t)
+
 type docker_unit_file_t;
 systemd_unit_file(docker_unit_file_t)
 
@@ -78,6 +78,8 @@ allow docker_t self:unix_stream_socket create_stream_socket_perms;
 allow docker_t self:tcp_socket create_stream_socket_perms;
 allow docker_t self:udp_socket create_socket_perms;
 allow docker_t self:capability2 block_suspend;
+
+docker_auth_stream_connect(docker_t)
 
 manage_files_pattern(docker_t, docker_home_t, docker_home_t)
 manage_dirs_pattern(docker_t, docker_home_t, docker_home_t)
@@ -405,14 +407,60 @@ optional_policy(`
     fs_dontaudit_remount_tmpfs(svirt_sandbox_domain)
     dev_dontaudit_mounton_sysfs(svirt_sandbox_domain)
 
-    tunable_policy(`virt_sandbox_use_fusefs',`
-	fs_manage_fusefs_dirs(svirt_sandbox_domain)
-	fs_manage_fusefs_files(svirt_sandbox_domain)
-	fs_manage_fusefs_symlinks(svirt_sandbox_domain)
-    ')	
      gen_require(`
         attribute domain;
      ')
 
      dontaudit svirt_sandbox_domain domain:key {search link};
 ')
+
+# systemd_dbus_chat_machined(docker_t)
+optional_policy(`
+	gen_require(`
+		type systemd_machined_t;
+		class dbus send_msg;
+	')
+
+	allow docker_t systemd_machined_t:dbus send_msg;
+	allow systemd_machined_t docker_t:dbus send_msg;
+	ps_process_pattern(systemd_machined_t, docker_t)
+	ps_process_pattern(systemd_machined_t, spc_t)
+
+	# This is a bug, but need for now.
+	kernel_read_unlabeled_state(systemd_machined_t)
+	optional_policy(`
+		virt_stub_svirt_sandbox_domain()
+		ps_process_pattern(systemd_machined_t, svirt_sandbox_domain)
+		docker_read_share_files(systemd_machined_t)
+		allow systemd_machined_t self:capability {dac_override sys_admin setgid sys_chroot };
+		auth_use_nsswitch(systemd_machined_t)
+	')
+')
+
+########################################
+#
+# docker_auth local policy
+#
+allow docker_auth_t self:fifo_file rw_fifo_file_perms;
+allow docker_auth_t self:unix_stream_socket create_stream_socket_perms;
+dontaudit docker_auth_t self:capability net_admin;
+
+docker_stream_connect(docker_auth_t)
+
+manage_dirs_pattern(docker_auth_t, docker_plugin_var_run_t, docker_plugin_var_run_t)
+manage_files_pattern(docker_auth_t, docker_plugin_var_run_t, docker_plugin_var_run_t)
+manage_sock_files_pattern(docker_auth_t, docker_plugin_var_run_t, docker_plugin_var_run_t)
+manage_lnk_files_pattern(docker_auth_t, docker_plugin_var_run_t, docker_plugin_var_run_t)
+files_pid_filetrans(docker_auth_t, docker_plugin_var_run_t, { dir file lnk_file sock_file })
+
+domain_use_interactive_fds(docker_auth_t)
+
+kernel_read_net_sysctls(docker_auth_t)
+
+auth_use_nsswitch(docker_auth_t)
+
+files_read_etc_files(docker_auth_t)
+
+miscfiles_read_localization(docker_auth_t)
+
+sysnet_dns_name_resolve(docker_auth_t)


### PR DESCRIPTION
Shouldn't we just be checking this into master and then cherry picking for fedora and rhel.

Fedora should be master.